### PR TITLE
Add first draft of Bernstein polynomial flow

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -12,7 +12,7 @@ from zuko.flows import *
 torch.set_default_dtype(torch.float64)
 
 
-@pytest.mark.parametrize('F', [GMM, NICE, MAF, NSF, SOSPF, NAF, UNAF, CNF, GF])
+@pytest.mark.parametrize('F', [GMM, NICE, MAF, NSF, SOSPF, NAF, UNAF, CNF, GF, BERN])
 def test_flows(tmp_path: Path, F: callable):
     flow = F(3, 5)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -28,6 +28,7 @@ def test_univariate_transforms(batched: bool):
         GaussianizationTransform(randn(*batch, 8), randn(*batch, 8)),
         UnconstrainedMonotonicTransform(lambda x: torch.exp(-x**2) + 1e-2, randn(batch)),
         SOSPolynomialTransform(randn(*batch, 3, 5), randn(batch)),
+        BernTransform(randn(*batch, 5)),
     ]
 
     for t in ts:


### PR DESCRIPTION
Hello,

I am the co-author of the Bernstein-Flows paper https://arxiv.org/abs/2004.00464 in which we constructed a one-dimensional flow based on Bernstein polynomials. We already have a TF [implementation](https://github.com/MArpogaus/TensorFlow-Probability-Bernstein-Polynomial-Bijector).
This flow would fit nicely in the zuko framework as an alternative to NSF. I am not an expert in software development and pytorch. I managed to write a transformation and also a flow. The "test_transform" works and I have usd the flow successfully for training, but I still have an exception in the unit test (test_flows) at the following position

```python
for p in flow.parameters():
    assert p.grad is not None
```
I tried hard but could not find any reason why this was failing. Possibly I lack the knowledge of the bells and whistles of your package. Could you please consider the request? 

Best,
Oliver and Marcel (@marpogaus)