### PR TITLE
Fallback to element-wise transform for univariate flows

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -79,9 +79,6 @@ def test_triangular_transforms():
         GeneralCouplingTransform,
         MaskedAutoregressiveTransform,
         partial(MaskedAutoregressiveTransform, passes=2),
-        NeuralAutoregressiveTransform,
-        partial(NeuralAutoregressiveTransform, passes=2),
-        UnconstrainedNeuralAutoregressiveTransform,
     ]
 
     for T in Ts:

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -15,6 +15,7 @@ from torch.distributions import Transform
 from typing import *
 
 from .core import *
+from .gaussianization import ElementWiseTransform
 from ..distributions import DiagNormal
 from ..transforms import *
 from ..nn import MaskedMLP
@@ -64,6 +65,20 @@ class MaskedAutoregressiveTransform(LazyTransform):
         >>> t(c).inv(y)
         tensor([-0.9485,  1.5290,  0.2018])
     """
+
+    def __new__(
+        cls,
+        features: int = None,
+        context: int = 0,
+        passes: int = None,
+        order: LongTensor = None,
+        *args,
+        **kwargs,
+    ) -> LazyTransform:
+        if features is None or features > 1:
+            return super().__new__(cls)
+        else:
+            return ElementWiseTransform(features, context, *args, **kwargs)
 
     def __init__(
         self,

--- a/zuko/flows/coupling.py
+++ b/zuko/flows/coupling.py
@@ -14,6 +14,7 @@ from torch.distributions import Transform
 from typing import *
 
 from .core import *
+from .gaussianization import ElementWiseTransform
 from ..distributions import DiagNormal
 from ..transforms import *
 from ..nn import MLP
@@ -60,6 +61,19 @@ class GeneralCouplingTransform(LazyTransform):
         >>> t(c).inv(y)
         tensor([-0.8743,  0.6232,  1.2439])
     """
+
+    def __new__(
+        cls,
+        features: int = None,
+        context: int = 0,
+        mask: BoolTensor = None,
+        *args,
+        **kwargs,
+    ) -> LazyTransform:
+        if features is None or features > 1:
+            return super().__new__(cls)
+        else:
+            return ElementWiseTransform(features, context, *args, **kwargs)
 
     def __init__(
         self,


### PR DESCRIPTION
Unconditional univariate auto-regressive and coupling flows cannot be instantiated, as it would lead to an ill-defined `MaskedMLP`. With this PR, `MaskedAutoregressiveTransform` and `GeneralCouplingTransform` fallback to `ElementWiseTransform` when `features=1`.