### PR TITLE
Support for adjacency matrices in autoregressive models

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -105,8 +105,8 @@ def test_triangular_transforms():
         assert torch.allclose(t(c).inv(y), x, atol=1e-4), T
 
         # Jacobian
-        t = T(7)
-        x = randn(7)
+        t = T(3)
+        x = randn(3)
         y = t()(x)
 
         J = torch.autograd.functional.jacobian(t(), x)
@@ -170,6 +170,6 @@ def test_adjacency_matrix():
         ))
         with pytest.raises(
             AssertionError,
-            match="`adjacency` should be a 2-dimensional squared tensor (a matrix).",
+            match="`adjacency` should be a 2-dimensional squared tensor \(a matrix\).",
         ):
             t = T(4, adjacency=adjacency)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -170,6 +170,6 @@ def test_adjacency_matrix():
         ))
         with pytest.raises(
             AssertionError,
-            match="`adjacency` should be a 2-dimensional squared tensor \(a matrix\).",
+            match=r"`adjacency` should be a 2-dimensional squared tensor \(a matrix\).",
         ):
             t = T(4, adjacency=adjacency)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -82,7 +82,7 @@ def test_triangular_transforms():
         GeneralCouplingTransform,
         MaskedAutoregressiveTransform,
         partial(MaskedAutoregressiveTransform, passes=2),
-        partial(MaskedAutoregressiveTransform, adjacency=adjacency)
+        partial(MaskedAutoregressiveTransform, adjacency=adjacency),
     ]
 
     for T in Ts:
@@ -147,7 +147,9 @@ def test_adjacency_matrix():
             (True, False, False, False),
             (False, True, True, True),
         ))
-        with pytest.raises(AssertionError, match="The diagonal of `adjacency` should be all ones."):
+        with pytest.raises(
+            AssertionError, match="The diagonal of `adjacency` should be all ones."
+        ):
             t = T(4, adjacency=adjacency)
 
         # With cycles (2, 4)
@@ -166,6 +168,8 @@ def test_adjacency_matrix():
             (True, True, False, False),
             (True, False, True, False),
         ))
-        with pytest.raises(AssertionError, match="`adjacency` should be a 2-dimensional squared tensor (a matrix)."):
+        with pytest.raises(
+            AssertionError,
+            match="`adjacency` should be a 2-dimensional squared tensor (a matrix).",
+        ):
             t = T(4, adjacency=adjacency)
-

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -107,3 +107,35 @@ def test_triangular_transforms():
 
         assert torch.allclose(t().log_abs_det_jacobian(x, y), ladj, atol=1e-4), T
         assert torch.allclose(J.diag().abs().log().sum(), ladj, atol=1e-4), T
+
+
+def test_adjacency_matrix():
+    Ts = [
+        MaskedAutoregressiveTransform,
+    ]
+
+    for T in Ts:
+        # With adjacency matrix
+        adjacency = torch.tensor((
+            (False, False, False, False),
+            (True, False, False, False),
+            (True, False, False, False),
+            (False, True, True, False),
+        ))
+        t = T(4, adjacency=adjacency)
+        x = randn(4)
+        y = t()(x)
+
+        J = torch.autograd.functional.jacobian(t(), x)
+        ladj = torch.linalg.slogdet(J).logabsdet
+
+        tladj = t().log_abs_det_jacobian(x, y)
+        Jladj = J.diag().abs().log().sum()
+
+        assert torch.allclose(tladj, ladj, atol=1e-4), T
+        assert torch.allclose(Jladj, ladj, atol=1e-4), T
+
+        assert torch.allclose(tladj * (~adjacency).float(), torch.zeros_like(tladj), atol=1e-4), T
+        assert torch.allclose(Jladj * (~adjacency).float(), torch.zeros_like(Jladj), atol=1e-4), T
+
+

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -74,7 +74,8 @@ def test_triangular_transforms():
     order = torch.randperm(5)
 
     adjacency = torch.rand((5, 5)) < 0.25
-    adjacency = torch.tril(adjacency, diagonal=-1)
+    adjacency = adjacency + torch.eye(5, dtype=bool)
+    adjacency = torch.tril(adjacency)
     adjacency[1, 0] = True
     adjacency = adjacency[order, :][:, order]
 
@@ -126,7 +127,8 @@ def test_adjacency_matrix():
     order = torch.randperm(5)
 
     adjacency = torch.rand((5, 5)) < 0.25
-    adjacency = torch.tril(adjacency, diagonal=-1)
+    adjacency = adjacency + torch.eye(5, dtype=bool)
+    adjacency = torch.tril(adjacency)
     adjacency[1, 0] = True
     adjacency = adjacency[order, :][:, order]
 
@@ -135,13 +137,13 @@ def test_adjacency_matrix():
 
     J = torch.autograd.functional.jacobian(t(), x)
 
-    assert (J[~(adjacency + torch.eye(5, dtype=bool))] == 0).all()
+    assert (J[~adjacency] == 0).all()
 
-    # With True in the diagonal
+    # With False in the diagonal
     adjacency_invalid = adjacency.clone()
-    adjacency_invalid[0, 0] = True
+    adjacency_invalid[0, 0] = False
 
-    with pytest.raises(AssertionError, match="'adjacency' should have zeros on the diagonal."):
+    with pytest.raises(AssertionError, match="'adjacency' should have ones on the diagonal."):
         t = T(5, adjacency=adjacency_invalid)
 
     # With cycles

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -71,11 +71,18 @@ def test_flows(tmp_path: Path, F: callable):
 
 
 def test_triangular_transforms():
+    adjacency = torch.tensor((
+        (True, False, False),
+        (True, True, False),
+        (True, False, True),
+    ))
+
     Ts = [
         ElementWiseTransform,
         GeneralCouplingTransform,
         MaskedAutoregressiveTransform,
         partial(MaskedAutoregressiveTransform, passes=2),
+        partial(MaskedAutoregressiveTransform, adjacency=adjacency)
     ]
 
     for T in Ts:

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -129,11 +129,8 @@ def test_adjacency_matrix():
         J = torch.autograd.functional.jacobian(t(), x)
         ladj = torch.linalg.slogdet(J).logabsdet
 
-        tladj = t().log_abs_det_jacobian(x, y)
-        Jladj = J.diag().abs().log().sum()
+        assert torch.allclose(t().log_abs_det_jacobian(x, y), ladj, atol=1e-4), T
+        assert torch.allclose(J.diag().abs().log().sum(), ladj, atol=1e-4), T
 
-        assert torch.allclose(tladj, ladj, atol=1e-4), T
-        assert torch.allclose(Jladj, ladj, atol=1e-4), T
-
-        assert torch.allclose(tladj * (~adjacency).float(), torch.zeros_like(tladj), atol=1e-4), T
-        assert torch.allclose(Jladj * (~adjacency).float(), torch.zeros_like(Jladj), atol=1e-4), T
+        adjacency = adjacency + torch.eye(adjacency.size(0)).bool()
+        assert torch.allclose(J * (~adjacency).float(), torch.zeros_like(J), atol=1e-4), T

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -137,5 +137,3 @@ def test_adjacency_matrix():
 
         assert torch.allclose(tladj * (~adjacency).float(), torch.zeros_like(tladj), atol=1e-4), T
         assert torch.allclose(Jladj * (~adjacency).float(), torch.zeros_like(Jladj), atol=1e-4), T
-
-

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -133,6 +133,7 @@ class MaskedAutoregressiveTransform(LazyTransform):
             adjacency.mul_(
                 ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
             )
+            adjacency = torch.repeat_interleave(adjacency.bool(), repeats=2, dim=0)
 
         # Hyper network
         self.hyper = MaskedMLP(adjacency, **kwargs)

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -128,11 +128,8 @@ class MaskedAutoregressiveTransform(LazyTransform):
             out_order = torch.repeat_interleave(self.order, self.total)
             adjacency = out_order[:, None] > in_order
         else:
-            adjacency.mul_(  # Remove the diagonal (if it is non-zero)
-                ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
-            )
-
-            self._check_adjacency(adjacency)
+            diameter = self._check_adjacency(adjacency)
+            self.passes = diameter
 
             adjacency = torch.cat(
                 (adjacency, torch.ones((adjacency.shape[0], context), dtype=bool)), dim=1
@@ -142,34 +139,41 @@ class MaskedAutoregressiveTransform(LazyTransform):
         # Hyper network
         self.hyper = MaskedMLP(adjacency, **kwargs)
 
-    def _check_adjacency(self, adjacency: BoolTensor) -> None:
+    def _check_adjacency(self, adjacency: BoolTensor) -> int:
+        r"""Checks that adjacency is valid (squared tensor, zeroed diagonal, and acyclic)
+        Args:
+            adjacency: The adjacency matrix.
+
+        Returns:
+            The diameter of the adjacency matrix (which describes the number of passes).
+            Based on the code for computing the topological generations in networkx
+            # https://networkx.org/documentation/stable/_modules/networkx/algorithms/dag.html#is_directed_acyclic_graph
+        """
         assert (len(adjacency.size()) == 2) and (adjacency.size(0) == adjacency.size(1)), (
-            "The adjacency matrix" "should be squared"
+            "`adjacency` should be a 2-dimensional squared tensor (a matrix)."
         )
 
-        # Algorithm to compute all the topological generations
-        # Adapted and simplified from the networkx library:
-        # https://networkx.org/documentation/stable/_modules/networkx/algorithms/dag.html#is_directed_acyclic_graph
-        all_generations = []
-        indegree_map = {v: d.item() for v, d in enumerate(adjacency.sum(dim=1)) if d > 0}
-        zero_indegree = [v for v in range(adjacency.size(0)) if v not in indegree_map]
+        assert adjacency.diag().all(), "The diagonal of `adjacency` should be all ones."
+        adjacency.mul_(  # Remove the diagonal
+            ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
+        )
 
+        all_generations = []
+        indegree = adjacency.sum(dim=1).tolist()
+        zero_indegree = [n for n, d in enumerate(indegree) if d == 0]
         while zero_indegree:
-            this_generation = zero_indegree
-            zero_indegree = []
+            this_generation, zero_indegree = zero_indegree, []
             for node in this_generation:
                 for child in adjacency[:, node].nonzero():
                     child = child.item()
-                    indegree_map[child] -= 1
-                    if indegree_map[child] == 0:
+                    indegree[child] -= 1
+                    if indegree[child] == 0:
                         zero_indegree.append(child)
-                        del indegree_map[child]
             all_generations.append(this_generation)
 
-        assert not indegree_map, "The adjacency matrix contains cycles"
+        assert all(d == 0 for d in indegree), "The graph contains cycles."
 
-        self.passes = len(all_generations)  # Graph diameter
-        self.order = torch.tensor(reduce(list.__add__, all_generations))
+        return len(all_generations)  # Graph diameter
 
     def extra_repr(self) -> str:
         base = self.univariate(*map(torch.randn, self.shapes))

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -282,10 +282,10 @@ class MAF(Flow):
         randperm: bool = False,
         **kwargs,
     ):
-        orders = (
+        orders = [
             torch.arange(features),
             torch.flipud(torch.arange(features)),
-        )
+        ]
 
         transforms = [
             MaskedAutoregressiveTransform(

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -7,7 +7,7 @@ __all__ = [
 
 import torch
 
-from functools import partial, reduce
+from functools import partial
 from math import ceil, prod
 from torch import BoolTensor, LongTensor, Size, Tensor
 from torch.distributions import Transform
@@ -148,9 +148,9 @@ class MaskedAutoregressiveTransform(LazyTransform):
             Based on the code for computing the topological generations in networkx
             # https://networkx.org/documentation/stable/_modules/networkx/algorithms/dag.html#is_directed_acyclic_graph
         """
-        assert (len(adjacency.size()) == 2) and (adjacency.size(0) == adjacency.size(1)), (
-            "`adjacency` should be a 2-dimensional squared tensor (a matrix)."
-        )
+        assert (len(adjacency.size()) == 2) and (
+            adjacency.size(0) == adjacency.size(1)
+        ), "`adjacency` should be a 2-dimensional squared tensor (a matrix)."
 
         assert adjacency.diag().all(), "The diagonal of `adjacency` should be all ones."
         adjacency.mul_(  # Remove the diagonal

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -218,8 +218,6 @@ class MAF(Flow):
         randperm: Whether features are randomly permuted between transformations or not.
             If :py:`False`, features are in ascending (descending) order for even
             (odd) transformations.
-        adjacency: Adjacency matrix that all layers of the flow should follow.
-            If different from :py:`None`, then `randperm` should be :py:`False`.
         kwargs: Keyword arguments passed to :class:`MaskedAutoregressiveTransform`.
 
     Example:
@@ -280,24 +278,18 @@ class MAF(Flow):
         context: int = 0,
         transforms: int = 3,
         randperm: bool = False,
-        adjacency: BoolTensor = None,
         **kwargs,
     ):
-        assert (adjacency is None) or not randperm
-
-        orders = (None, None)
-        if adjacency is None:
-            orders = (
-                torch.arange(features),
-                torch.flipud(torch.arange(features)),
-            )
+        orders = (
+            torch.arange(features),
+            torch.flipud(torch.arange(features)),
+        )
 
         transforms = [
             MaskedAutoregressiveTransform(
                 features=features,
                 context=context,
                 order=torch.randperm(features) if randperm else orders[i % 2],
-                adjacency=adjacency,
                 **kwargs,
             )
             for i in range(transforms)

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -52,6 +52,7 @@ class MaskedAutoregressiveTransform(LazyTransform):
         MaskedAutoregressiveTransform(
           (base): MonotonicAffineTransform()
           (order): [0, 1, 2]
+          (adjacency): None
           (hyper): MaskedMLP(
             (0): MaskedLinear(in_features=7, out_features=64, bias=True)
             (1): ReLU()

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -130,11 +130,13 @@ class MaskedAutoregressiveTransform(LazyTransform):
         else:
             assert (len(adjacency.size()) == 2) and (adjacency.size(0) == adjacency.size(1))
 
-            # Remove the diagonal
-            adjacency.mul_(
+            adjacency.mul_(  # Remove the diagonal
                 ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
             )
-            adjacency = torch.repeat_interleave(adjacency.bool(), repeats=2, dim=0)
+            adjacency = torch.cat(
+                (adjacency, torch.ones((adjacency.shape[0], context), dtype=bool)), dim=1
+            )
+            adjacency = torch.repeat_interleave(adjacency.bool(), repeats=self.total, dim=0)
 
         # Hyper network
         self.hyper = MaskedMLP(adjacency, **kwargs)

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -108,10 +108,12 @@ class MaskedAutoregressiveTransform(LazyTransform):
             passes = features
         self.passes = min(max(passes, 1), features)
 
-        assert (order is None) or (adjacency is None), \
-            "Parameters `order` and `adjacency_matrix` are mutually exclusive."
-        assert (passes == features) or (adjacency is None), \
-            "When using `adjacency_matrix`, `passes` has to be the number of features."
+        assert (order is None) or (
+            adjacency is None
+        ), "Parameters `order` and `adjacency_matrix` are mutually exclusive."
+        assert (passes == features) or (
+            adjacency is None
+        ), "When using `adjacency_matrix`, `passes` has to be the number of features."
 
         if adjacency is None:
             if order is None:
@@ -128,7 +130,9 @@ class MaskedAutoregressiveTransform(LazyTransform):
             assert (len(adjacency.size()) == 2) and (adjacency.size(0) == adjacency.size(1))
 
             # Remove the diagonal
-            adjacency.mul_(~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device))
+            adjacency.mul_(
+                ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
+            )
 
         # Hyper network
         self.hyper = MaskedMLP(adjacency, **kwargs)

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -39,11 +39,11 @@ class MaskedAutoregressiveTransform(LazyTransform):
             :py:`None`, use the number of features instead, making the transformation
             fully autoregressive. Coupling corresponds to :py:`passes=2`.
         order: The feature ordering. If :py:`None`, use :py:`range(features)` instead.
-        univariate: The univariate transformation constructor.
-        shapes: The shapes of the univariate transformation parameters.
         adjacency: The adjacency matrix describing the factorization of the
             joint distribution. If different from :py:`None`, then `order` and `passes`
             arguments are ignored and inferred directly from the adjacency matrix.
+        univariate: The univariate transformation constructor.
+        shapes: The shapes of the univariate transformation parameters.
         kwargs: Keyword arguments passed to :class:`zuko.nn.MaskedMLP`.
 
     Example:
@@ -90,9 +90,9 @@ class MaskedAutoregressiveTransform(LazyTransform):
         context: int = 0,
         passes: int = None,
         order: LongTensor = None,
+        adjacency: BoolTensor = None,
         univariate: Callable[..., Transform] = MonotonicAffineTransform,
         shapes: Sequence[Size] = ((), ()),
-        adjacency: BoolTensor = None,
         **kwargs,
     ):
         super().__init__()

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -9,7 +9,7 @@ import torch
 
 from functools import partial
 from math import ceil, prod
-from torch import LongTensor, BoolTensor, Size, Tensor
+from torch import BoolTensor, LongTensor, Size, Tensor
 from torch.distributions import Transform
 from typing import Callable, Sequence
 

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -197,6 +197,7 @@ class MAF(Flow):
             (0): MaskedAutoregressiveTransform(
               (base): MonotonicAffineTransform()
               (order): [0, 1, 2]
+              (adjacency): None
               (hyper): MaskedMLP(
                 (0): MaskedLinear(in_features=7, out_features=64, bias=True)
                 (1): ReLU()
@@ -208,6 +209,7 @@ class MAF(Flow):
             (1): MaskedAutoregressiveTransform(
               (base): MonotonicAffineTransform()
               (order): [2, 1, 0]
+              (adjacency): None
               (hyper): MaskedMLP(
                 (0): MaskedLinear(in_features=7, out_features=64, bias=True)
                 (1): ReLU()
@@ -219,6 +221,7 @@ class MAF(Flow):
             (2): MaskedAutoregressiveTransform(
               (base): MonotonicAffineTransform()
               (order): [0, 1, 2]
+              (adjacency): None
               (hyper): MaskedMLP(
                 (0): MaskedLinear(in_features=7, out_features=64, bias=True)
                 (1): ReLU()

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -126,6 +126,7 @@ class MaskedAutoregressiveTransform(LazyTransform):
             out_order = torch.repeat_interleave(self.order, self.total)
             adjacency = out_order[:, None] > in_order
         else:
+            adjacency = adjacency.clone()  # Because we are going to remove the diagonal
             diameter = self._check_adjacency(adjacency)
             if passes is None:
                 self.passes = diameter
@@ -153,7 +154,7 @@ class MaskedAutoregressiveTransform(LazyTransform):
         ), "`adjacency` should be a 2-dimensional squared tensor (a matrix)."
 
         assert adjacency.diag().all(), "The diagonal of `adjacency` should be all ones."
-        adjacency.mul_(  # Remove the diagonal
+        adjacency = adjacency.mul_(  # Remove the diagonal
             ~torch.eye(adjacency.size(0), dtype=torch.bool, device=adjacency.device)
         )
 

--- a/zuko/flows/neural.py
+++ b/zuko/flows/neural.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from functools import partial
-from torch import BoolTensor, Tensor
+from torch import Tensor
 from torch.distributions import Transform
 from typing import Any, Dict
 
@@ -126,8 +126,6 @@ class NAF(Flow):
             (odd) transformations.
         signal: The number of signal features of the monotonic network.
         network: Keyword arguments passed to :class:`MNN`.
-        adjacency: Adjacency matrix that all layers of the flow should follow.
-            If different from :py:`None`, then `randperm` should be :py:`False`.
         kwargs: Keyword arguments passed to :class:`zuko.flows.autoregressive.MaskedAutoregressiveTransform`.
     """
 
@@ -139,17 +137,12 @@ class NAF(Flow):
         randperm: bool = False,
         signal: int = 16,
         network: Dict[str, Any] = {},  # noqa: B006
-        adjacency: BoolTensor = None,
         **kwargs,
     ):
-        assert (adjacency is None) or not randperm
-
-        orders = (None, None)
-        if adjacency is None:
-            orders = [
-                torch.arange(features),
-                torch.flipud(torch.arange(features)),
-            ]
+        orders = [
+            torch.arange(features),
+            torch.flipud(torch.arange(features)),
+        ]
 
         transforms = [
             MaskedAutoregressiveTransform(
@@ -158,7 +151,6 @@ class NAF(Flow):
                 order=torch.randperm(features) if randperm else orders[i % 2],
                 univariate=MNN(signal=signal, stack=features, **network),
                 shapes=[(signal,)],
-                adjacency=adjacency,
                 **kwargs,
             )
             for i in range(transforms)
@@ -198,8 +190,6 @@ class UNAF(Flow):
             (odd) transformations.
         signal: The number of signal features of the monotonic network.
         network: Keyword arguments passed to :class:`UMNN`.
-        adjacency: Adjacency matrix that all layers of the flow should follow.
-            If different from :py:`None`, then `randperm` should be :py:`False`.
         kwargs: Keyword arguments passed to :class:`zuko.flows.autoregressive.MaskedAutoregressiveTransform`.
     """
 
@@ -211,17 +201,12 @@ class UNAF(Flow):
         randperm: bool = False,
         signal: int = 16,
         network: Dict[str, Any] = {},  # noqa: B006
-        adjacency: BoolTensor = None,
         **kwargs,
     ):
-        assert (adjacency is None) or not randperm
-
-        orders = (None, None)
-        if adjacency is None:
-            orders = [
-                torch.arange(features),
-                torch.flipud(torch.arange(features)),
-            ]
+        orders = [
+            torch.arange(features),
+            torch.flipud(torch.arange(features)),
+        ]
 
         transforms = [
             MaskedAutoregressiveTransform(
@@ -230,7 +215,6 @@ class UNAF(Flow):
                 order=torch.randperm(features) if randperm else orders[i % 2],
                 univariate=UMNN(signal=signal, stack=features, **network),
                 shapes=[(signal,), ()],
-                adjacency=adjacency,
                 **kwargs,
             )
             for i in range(transforms)

--- a/zuko/flows/neural.py
+++ b/zuko/flows/neural.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 
 from functools import partial
-from torch import Tensor, BoolTensor
+from torch import BoolTensor, Tensor
 from torch.distributions import Transform
 from typing import Any, Dict
 

--- a/zuko/transforms.py
+++ b/zuko/transforms.py
@@ -981,7 +981,9 @@ class CouplingTransform(Transform):
 
     Arguments:
         meta: A function which returns a transformation :math:`f` given :math:`x_a`.
-        mask: A coupling mask defining the split :math:`x \to (x_a, x_b)`.
+        mask: A coupling mask defining the split :math:`x \to (x_a, x_b)`. Ones
+            correspond to the constant split :math:`x_a` and zeros to the transformed
+            split :math:`x_b`.
     """
 
     domain = constraints.real_vector


### PR DESCRIPTION
This is an implementation of #53, in which I add support to provide an adjacency matrix to the autoregressive models, instead of using the ordering between variables.

I have added some asserts to make sure I cover all corner cases (e.g., providing both an ordering and an adjacency matrix), and added tests to make sure that the zero-entries of the adjacency matrix are indeed zero when computing the Jacobian matrix.

I might have missed something, and I am happy to fix it if that's the case.

PS: I read the policy about commit messages a bit too late, we can merge all commits into a single one and write an appropiate commit message.