### PR TITLE
⚡️ Enable training with CUDA

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -13,7 +13,12 @@ def test_distributions(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     ds = [
         NormalizingFlow(ExpTransform(), Gamma(2.0, 1.0)),

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,5 +1,6 @@
 r"""Tests for the zuko.distributions module."""
 
+import pytest
 import torch
 
 from torch.distributions import *
@@ -7,7 +8,13 @@ from torch.distributions import *
 from zuko.distributions import *
 
 
-def test_distributions():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_distributions(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     ds = [
         NormalizingFlow(ExpTransform(), Gamma(2.0, 1.0)),
         Joint(Uniform(0.0, 1.0), Normal(0.0, 1.0)),

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -16,7 +16,12 @@ def test_flows(tmp_path: Path, F: callable, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     flow = F(3, 5)
 
@@ -81,7 +86,12 @@ def test_triangular_transforms(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     order = torch.randperm(5)
 
@@ -137,7 +147,12 @@ def test_adjacency_matrix(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     T = MaskedAutoregressiveTransform
 

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -11,7 +11,13 @@ from zuko.flows import *
 
 
 @pytest.mark.parametrize("F", [NICE, MAF, NSF, SOSPF, NAF, UNAF, CNF, GF, BPF])
-def test_flows(tmp_path: Path, F: callable):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_flows(tmp_path: Path, F: callable, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     flow = F(3, 5)
 
     # Evaluation of log_prob
@@ -70,7 +76,13 @@ def test_flows(tmp_path: Path, F: callable):
     assert repr(flow)
 
 
-def test_triangular_transforms():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_triangular_transforms(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     order = torch.randperm(5)
 
     adjacency = torch.rand((5, 5)) < 0.25
@@ -120,7 +132,13 @@ def test_triangular_transforms():
         assert torch.allclose(J.diag().abs().log().sum(), ladj, atol=1e-4), T
 
 
-def test_adjacency_matrix():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_adjacency_matrix(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     T = MaskedAutoregressiveTransform
 
     # With a valid adjacency matrix

--- a/tests/test_mixtures.py
+++ b/tests/test_mixtures.py
@@ -15,7 +15,12 @@ def test_mixtures(tmp_path: Path, M: callable, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     mixture = M(3, 5)
 

--- a/tests/test_mixtures.py
+++ b/tests/test_mixtures.py
@@ -10,7 +10,13 @@ from zuko.mixtures import *
 
 
 @pytest.mark.parametrize("M", [GMM])
-def test_mixtures(tmp_path: Path, M: callable):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_mixtures(tmp_path: Path, M: callable, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     mixture = M(3, 5)
 
     # Evaluation of log_prob

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -10,7 +10,13 @@ from zuko.nn import *
 
 
 @pytest.mark.parametrize("bias", [True, False])
-def test_Linear(bias: bool):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_Linear(bias: bool, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     net = Linear(3, 5, bias=True)
 
     # Non-batched
@@ -29,7 +35,13 @@ def test_Linear(bias: bool):
 
 @pytest.mark.parametrize("activation", [None, torch.nn.ELU])
 @pytest.mark.parametrize("normalize", [True, False])
-def test_MLP(activation: callable, normalize: bool):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_MLP(activation: callable, normalize: bool, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     net = MLP(3, 5, activation=activation, normalize=normalize)
 
     # Non-batched
@@ -47,7 +59,13 @@ def test_MLP(activation: callable, normalize: bool):
 
 
 @pytest.mark.parametrize("residual", [True, False])
-def test_MaskedMLP(residual: bool):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_MaskedMLP(residual: bool, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     adjacency = randn(5, 3) < 0
     net = MaskedMLP(adjacency, activation=nn.ELU, residual=residual)
 
@@ -71,7 +89,13 @@ def test_MaskedMLP(residual: bool):
     assert (J[~adjacency] == 0).all()
 
 
-def test_MonotonicMLP():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_MonotonicMLP(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     net = MonotonicMLP(3, 5)
 
     # Non-batched

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -15,7 +15,12 @@ def test_Linear(bias: bool, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     net = Linear(3, 5, bias=True)
 
@@ -40,7 +45,12 @@ def test_MLP(activation: callable, normalize: bool, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     net = MLP(3, 5, activation=activation, normalize=normalize)
 
@@ -64,7 +74,12 @@ def test_MaskedMLP(residual: bool, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     adjacency = randn(5, 3) < 0
     net = MaskedMLP(adjacency, activation=nn.ELU, residual=residual)
@@ -94,7 +109,12 @@ def test_MonotonicMLP(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     net = MonotonicMLP(3, 5)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,7 +10,13 @@ from zuko.transforms import *
 
 
 @pytest.mark.parametrize("batched", [False, True])
-def test_univariate_transforms(batched: bool):
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_univariate_transforms(batched: bool, device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     batch = (256,) if batched else ()
 
     ts = [
@@ -73,7 +79,13 @@ def test_univariate_transforms(batched: bool):
         assert torch.allclose(t.inv.log_abs_det_jacobian(y, z), ladj, atol=1e-4), t
 
 
-def test_multivariate_transforms():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_multivariate_transforms(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     A, B = torch.randn(5, 16), torch.randn(16, 5)
     f = lambda t, x: torch.sigmoid(x @ A) @ B
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -15,7 +15,12 @@ def test_univariate_transforms(batched: bool, device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     batch = (256,) if batched else ()
 
@@ -84,7 +89,12 @@ def test_multivariate_transforms(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     A, B = torch.randn(5, 16), torch.randn(16, 5)
     f = lambda t, x: torch.sigmoid(x @ A) @ B

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,13 @@ from torch import randn
 from zuko.utils import *
 
 
-def test_bisection():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_bisection(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     alpha = torch.tensor(1.0, requires_grad=True)
 
     f = lambda x: torch.cos(alpha * x)
@@ -29,7 +35,13 @@ def test_bisection():
     assert torch.allclose(grad_alpha, dalpha, atol=1e-6)
 
 
-def test_broadcast():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_broadcast(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     # Trivial
     a = randn(2, 3)
     (b,) = broadcast(a)
@@ -64,7 +76,13 @@ def test_broadcast():
     assert (a == c).all() and (b == d).all()
 
 
-def test_gauss_legendre():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_gauss_legendre(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     # Polynomial
     alpha = torch.tensor(1.0, requires_grad=True)
 
@@ -85,7 +103,13 @@ def test_gauss_legendre():
     assert torch.allclose(grad_alpha, dalpha, atol=1e-6)
 
 
-def test_odeint():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_odeint(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     # Linear
     alpha = torch.tensor(1.0, requires_grad=True)
     t = torch.tensor(3.0, requires_grad=True)
@@ -108,7 +132,13 @@ def test_odeint():
     assert torch.allclose(grad_alpha, dalpha, atol=1e-6)
 
 
-def test_unpack():
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_unpack(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("No CUDA devices available")
+
+    torch.set_default_device(device)
+
     # Normal
     x = randn(26)
     y, z = unpack(x, ((1, 2, 3), (4, 5)))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,12 @@ def test_bisection(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     alpha = torch.tensor(1.0, requires_grad=True)
 
@@ -40,7 +45,12 @@ def test_broadcast(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     # Trivial
     a = randn(2, 3)
@@ -81,7 +91,12 @@ def test_gauss_legendre(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     # Polynomial
     alpha = torch.tensor(1.0, requires_grad=True)
@@ -108,7 +123,12 @@ def test_odeint(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     # Linear
     alpha = torch.tensor(1.0, requires_grad=True)
@@ -137,7 +157,12 @@ def test_unpack(device: str):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("No CUDA devices available")
 
-    torch.set_default_device(device)
+    try:
+        torch.set_default_device(device)
+    except AttributeError:
+        # torch.set_default_device() may not be available
+        if device != "cpu":
+            pytest.skip("torch.set_default_device() not supported")
 
     # Normal
     x = randn(26)

--- a/zuko/nn.py
+++ b/zuko/nn.py
@@ -270,7 +270,11 @@ class MaskedMLP(nn.Sequential):
         adjacency, inverse = torch.unique(adjacency, dim=0, return_inverse=True)
 
         # P_ij = 1 if A_ik = 1 for all k such that A_jk = 1
-        precedence = adjacency.int() @ adjacency.int().t() == adjacency.sum(dim=-1)
+        # PyTorch doesn't support this operation for integer arrays on CUDA devices
+        precedence = (
+            adjacency.cpu().int() @ adjacency.cpu().int().t() == adjacency.sum(dim=-1).cpu()
+        )
+        precedence = precedence.to(torch.get_default_device())
 
         # Layers
         layers = []

--- a/zuko/nn.py
+++ b/zuko/nn.py
@@ -274,7 +274,10 @@ class MaskedMLP(nn.Sequential):
         precedence = (
             adjacency.cpu().int() @ adjacency.cpu().int().t() == adjacency.sum(dim=-1).cpu()
         )
-        precedence = precedence.to(torch.get_default_device())
+        try:
+            precedence = precedence.to(torch.get_default_device())
+        except AttributeError:
+            precedence = torch.tensor(precedence.detach().cpu().numpy())
 
         # Layers
         layers = []


### PR DESCRIPTION
PR implementing the feature suggested in #58. The integer matmul operation needed for a masked autoregressive transform should be explicitly carried out on CPU and then migrated to the current default device. All other tensors get created on the default device anyway. This way, if the user calls `torch.set_default_device('cuda')`, that preference will be followed.

I have modified existing tests to make sure that no existing code should be broken by my modification; all tests are now performed on CPU and with CUDA to be sure they pass either way.