### PR TITLE
Add support for custom adjacency context in masked autoregressive transform 

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -167,27 +167,27 @@ def test_context_adjacency_matrix():
 
     # context adjacency
     adjacency_context = torch.rand((5, 2)) < 0.25
-    valid_adjacency = torch.concat((adjacency, adjacency_context), dim=1)
+    adjacency_valid = torch.cat((adjacency, adjacency_context), dim=1)
 
-    t = T(features=5, context=2, adjacency=valid_adjacency)
+    t = T(features=5, context=2, adjacency=adjacency_valid)
 
     x, c = randn(5), randn(2)
     y = t(c)(x)
-
-    J = torch.autograd.functional.jacobian(t(c), x)
-    assert (J[~adjacency] == 0).all()
 
     assert y.shape == x.shape
     assert y.requires_grad
     assert torch.allclose(t(c).inv(y), x, atol=1e-4)
 
+    J = torch.autograd.functional.jacobian(t(c), x)
+
+    assert (J[~adjacency] == 0).all()
     ladj = torch.linalg.slogdet(J).logabsdet
 
     assert torch.allclose(t(c).log_abs_det_jacobian(x, y), ladj, atol=1e-4)
     assert torch.allclose(J.diag().abs().log().sum(), ladj, atol=1e-4)
 
-    invalid_adjacency_context = torch.rand((5, 1)) < 0.25
-    invalid_adjacency = torch.concat((adjacency, invalid_adjacency_context), dim=1)
+    adjacency_invalid_context = torch.rand((5, 1)) < 0.25
+    adjacency_invalid = torch.cat((adjacency, adjacency_invalid_context), dim=1)
 
     with pytest.raises(AssertionError, match="'adjacency' should have 5 or 7 columns."):
-        t = T(features=5, context=2, adjacency=invalid_adjacency)
+        t = T(features=5, context=2, adjacency=adjacency_invalid)

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -181,6 +181,7 @@ def test_context_adjacency_matrix():
     J = torch.autograd.functional.jacobian(t(c), x)
 
     assert (J[~adjacency] == 0).all()
+
     ladj = torch.linalg.slogdet(J).logabsdet
 
     assert torch.allclose(t(c).log_abs_det_jacobian(x, y), ladj, atol=1e-4)

--- a/zuko/flows/autoregressive.py
+++ b/zuko/flows/autoregressive.py
@@ -144,7 +144,7 @@ class MaskedAutoregressiveTransform(LazyTransform):
         if context > 0:
             if adjacency_context is None:
                 adjacency_context = torch.ones((features, context), dtype=bool)
-            adjacency = torch.cat((adjacency, adjacency_context),dim=1)
+            adjacency = torch.cat((adjacency, adjacency_context), dim=1)
 
         adjacency = torch.repeat_interleave(adjacency, repeats=self.total, dim=0)
 


### PR DESCRIPTION
This PR implements [#64](https://github.com/probabilists/zuko/issues/64), adding support for user-defined structural constraints in the context features of MaskedAutoregressiveTransform.

Allows specifying an adjacency matrix of shape (features, features + context).

The right-most columns correspond to context-related constraints.

Adds assertions to verify shape validity.

Includes a test to ensure correct behavior.

No additional assumptions are made about the structure of the context adjacency beyond its shape.

Feel free to suggest any changes or additional constraints to enforce.