### PR TITLE
Correct typos in GMM error messages

### DIFF
--- a/tests/test_mixtures.py
+++ b/tests/test_mixtures.py
@@ -134,14 +134,17 @@ def test_gmm_insufficient_samples() -> None:
         gmm.initialize(torch.randn(6, 3), strategy="random")
 
 
-def test_gmm_unknown_init_strategy_error_message() -> None:
+def test_gmm_unknown_strategy() -> None:
     gmm = GMM(features=3, components=2, covariance_type="full")
 
     with pytest.raises(ValueError, match="Unknown clustering strategy"):
         gmm.initialize(torch.randn(16, 3), strategy="invalid")
 
 
-def test_gmm_unknown_covariance_error_message() -> None:
+def test_gmm_unknown_covariance_type() -> None:
+    with pytest.raises(ValueError, match="Unknown covariance type"):
+        gmm = GMM(features=3, components=2, covariance_type="invalid")
+
     gmm = GMM(features=3, components=2, covariance_type="full")
     gmm.covariance_type = "invalid"
 

--- a/tests/test_mixtures.py
+++ b/tests/test_mixtures.py
@@ -132,3 +132,18 @@ def test_gmm_insufficient_samples() -> None:
 
     with pytest.raises(AssertionError, match="The number of samples"):
         gmm.initialize(torch.randn(6, 3), strategy="random")
+
+
+def test_gmm_unknown_init_strategy_error_message() -> None:
+    gmm = GMM(features=3, components=2, covariance_type="full")
+
+    with pytest.raises(ValueError, match="Unknown clustering strategy"):
+        gmm.initialize(torch.randn(16, 3), strategy="invalid")
+
+
+def test_gmm_unknown_covariance_error_message() -> None:
+    gmm = GMM(features=3, components=2, covariance_type="full")
+    gmm.covariance_type = "invalid"
+
+    with pytest.raises(ValueError, match="Unknown covariance type"):
+        gmm.initialize(torch.randn(16, 3), strategy="random")

--- a/zuko/mixtures.py
+++ b/zuko/mixtures.py
@@ -123,7 +123,7 @@ class GMM(LazyDistribution):
         elif strategy == "kmeans++":
             centers = _cluster_kmeans_pp(x, self.components)
         else:
-            raise ValueError(f"Unkown clustering strategy '{strategy}'.")
+            raise ValueError(f"Unknown clustering strategy '{strategy}'.")
 
         match = torch.cdist(x, centers).argmin(dim=-1)
         match = torch.nn.functional.one_hot(match, num_classes=self.components).to(dtype=x.dtype)
@@ -140,7 +140,7 @@ class GMM(LazyDistribution):
         elif self.covariance_type == "spherical":
             covs = _estimate_spherical_cov(x, match, self.tied)
         else:
-            raise ValueError(f"Unkown covariance type '{self.covariance_type}'.")
+            raise ValueError(f"Unknown covariance type '{self.covariance_type}'.")
 
         if torch.is_tensor(covs):
             params = (probs.log(), means, covs)


### PR DESCRIPTION
## What changed
- Fixed two typoed `ValueError` messages in `GMM.initialize` from `Unkown` to `Unknown`.
- Added regression tests to ensure invalid strategy and invalid covariance type both raise the correctly spelled messages.

## Why
- Error messages are part of the public debugging surface. Correct spelling improves clarity and professionalism.
- Regression tests prevent these user-facing messages from regressing in future refactors.

## Testing
- ✅ `source .venv/bin/activate && pytest -q` (162 passed)